### PR TITLE
Add examples navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.2+1 - 2025-02-13
+
+- Remove dart analysis issues for better referencement.
+
 ## 0.0.2 - 2025-02-13
 
 - Added `QueuedNotification` for managing a queue of notifications.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add this dependency to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  flui_kit: ^0.0.2
+  flui_kit: ^0.0.2+1
 ```
 
 Then run:

--- a/example/lib/components/queed_notification_example.dart
+++ b/example/lib/components/queed_notification_example.dart
@@ -10,6 +10,9 @@ class QueedNotificationExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        title: const Text('Queed Notification Example'),
+      ),
       body: Stack(
         children: [
           Center(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:flui_kit_example/src/pages/home/home_page.dart';
 import 'package:flutter/material.dart';
 
 // import 'components/accordion_example.dart';
@@ -16,7 +17,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
-      home: DatePickerExample(),
+      home: HomePage(),
     );
   }
 }

--- a/example/lib/src/pages/home/home_page.dart
+++ b/example/lib/src/pages/home/home_page.dart
@@ -1,0 +1,108 @@
+import 'package:flui_kit_example/components/accordion_example.dart';
+import 'package:flui_kit_example/components/advanced_pagination_example.dart'
+    show AdvancedPaginationExample;
+import 'package:flui_kit_example/components/date_picker_example.dart'
+    show DatePickerExample;
+import 'package:flui_kit_example/components/multi_stepper_example.dart'
+    show MultiStepperExample;
+import 'package:flui_kit_example/components/plan_switcher_example.dart'
+    show PlanSwitcherExample;
+import 'package:flui_kit_example/components/queed_notification_example.dart'
+    show QueedNotificationExample;
+import 'package:flutter/material.dart';
+
+enum FluKitExample {
+  accordionExample("Accordion Example"),
+  advancedPaginationExample("Advanced Pagination Example"),
+  datePickerExample("Date Picker Example"),
+  multiStepperExample("Multi Stepper Example"),
+  planSwitcherExample("Plan Switcher Example"),
+  queedNotificationExample("Queed Notification Example");
+
+  final String title;
+
+  const FluKitExample(this.title);
+
+  static List<FluKitExample> getExampleList() => [
+        FluKitExample.accordionExample,
+        FluKitExample.advancedPaginationExample,
+        FluKitExample.datePickerExample,
+        FluKitExample.multiStepperExample,
+        FluKitExample.planSwitcherExample,
+        FluKitExample.queedNotificationExample,
+      ];
+}
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Flu Kit Examples'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: FluKitExample.getExampleList()
+              .map(
+                (e) => ListTile(
+                  title: Text(e.title),
+                  onTap: () => onTap(e, context),
+                ),
+              )
+              .toList(),
+        ),
+      ),
+    );
+  }
+
+  void onTap(FluKitExample e, BuildContext context) {
+    switch (e) {
+      case FluKitExample.accordionExample:
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => AccordionExample(),
+          ),
+        );
+        break;
+      case FluKitExample.advancedPaginationExample:
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => const AdvancedPaginationExample(),
+          ),
+        );
+        break;
+      case FluKitExample.datePickerExample:
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => const DatePickerExample(),
+          ),
+        );
+        break;
+      case FluKitExample.multiStepperExample:
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => MultiStepperExample(),
+          ),
+        );
+        break;
+      case FluKitExample.planSwitcherExample:
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => PlanSwitcherExample(),
+          ),
+        );
+        break;
+      case FluKitExample.queedNotificationExample:
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => QueedNotificationExample(),
+          ),
+        );
+        break;
+    }
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.0.2+1"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/lib/src/widgets/queed_notification.dart
+++ b/lib/src/widgets/queed_notification.dart
@@ -237,8 +237,6 @@ class QueedNotificationWidgetState extends State<QueedNotificationWidget>
         // case NotificationPosition.bottomLeft:
         // case NotificationPosition.bottomRight:
         return 16;
-      default:
-        return null;
     }
   }
 
@@ -251,8 +249,6 @@ class QueedNotificationWidgetState extends State<QueedNotificationWidget>
         // case NotificationPosition.bottomLeft:
         // case NotificationPosition.bottomRight:
         return 16;
-      default:
-        return null;
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flui_kit
 description: "A Flutter library offering modern high customizable components and screens for seamless app development."
-version: 0.0.2
+version: 0.0.2+1
 homepage: https://github.com/maeltoukap/flui_kit_package
 
 environment:


### PR DESCRIPTION
## Summary
This pull request introduces significant enhancements to the navigation experience within the Flu Kit library. The main focus is on improving user interaction by implementing a new `HomePage` that serves as a central hub for navigating various examples, along with the addition of an `AppBar` to the `QueedNotificationExample` widget for better context.

🎫 Issue link: N/A

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🔥 Breaking change
- [ ] 💣 Package Update
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
- [ ] 🏰 Code style update (formatting, local variables)

# Platforms

- [x] iOS
- [x] Android
- [x] Web
- [x] MacOS
- [x] Linux
- [x] Windows

# Changes done in

- [ ] Native code
- [x] Flutter code

# What can be impact

These changes aim to streamline navigation and improve the usability of the Flu Kit library, making it easier for users to explore and understand the various components available.

# Results of dev testing

Screenshot(iOS and Android): 
![flutter_01](https://github.com/user-attachments/assets/48baa7e6-e908-4009-a51d-73cd50eeb56c)

Screenrecording: N/A

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I've run the app on the real device